### PR TITLE
fix: Pin httpx version to resolve dependency conflict

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@ Flask
 openai~=1.23.0
 python-dotenv
 requests
+httpx~=0.27.0
 gunicorn
 supabase


### PR DESCRIPTION
This commit resolves a deployment failure caused by a `TypeError: Client.__init__() got an unexpected keyword argument 'proxies'`.

The error was due to an incompatibility between the newly pinned `openai>=1.23.0` library and an older, cached version of its dependency, `httpx`, in the deployment environment.

This fix pins the version of `httpx` to `~=0.27.0` in `requirements.txt` to ensure a compatible version is installed during the build process.