### PR TITLE
fix: Correctly format file uploads to OpenAI API

### DIFF
--- a/app.py
+++ b/app.py
@@ -233,8 +233,9 @@ def upload_file_to_vector_store():
         return jsonify({"error": "No selected file."}), 400
 
     try:
-        # 1. Upload the file to OpenAI
-        uploaded_file = client.files.create(file=file, purpose='assistants')
+        # 1. Upload the file to OpenAI, converting the FileStorage object to a tuple
+        # of (filename, file_bytes) which the library expects.
+        uploaded_file = client.files.create(file=(file.filename, file.read()), purpose='assistants')
 
         # 2. Add the file to the vector store
         vector_store_file = client.beta.vector_stores.files.create(


### PR DESCRIPTION
This commit fixes a `TypeError` that occurred during file uploads in the admin panel. The error was caused by passing a `werkzeug.FileStorage` object directly to the `openai.files.create` method, which does not accept this type.

The `upload_file_to_vector_store` function in `app.py` has been updated to read the file's content and pass it to the OpenAI client as a `(filename, file_bytes)` tuple. This is the correct format as expected by the library and resolves the issue.