### PR TITLE
fix: Restore connection between assistant and vector store

### DIFF
--- a/app.py
+++ b/app.py
@@ -111,7 +111,11 @@ def chat():
         supabase.table('chat_messages').insert({"session_id": thread_id, "message": user_message, "is_user": True}).execute()
         client.beta.threads.messages.create(thread_id=thread_id, role="user", content=user_message)
 
-        run = client.beta.threads.runs.create(assistant_id=ASSISTANT_ID, thread_id=thread_id)
+        run = client.beta.threads.runs.create(
+            assistant_id=ASSISTANT_ID,
+            thread_id=thread_id,
+            tool_resources={ "file_search": { "vector_store_ids": [VECTOR_STORE_ID] } }
+        )
         while run.status in ['queued', 'in_progress', 'requires_action']:
             time.sleep(1)
             run = client.beta.threads.runs.retrieve(thread_id=thread_id, run_id=run.id)


### PR DESCRIPTION
This commit fixes a critical regression where the assistant was giving generic responses instead of using information from the specified vector store.

The `client.beta.threads.runs.create` call in the `/chat` endpoint was missing the `tool_resources` parameter that explicitly links the run to the `VECTOR_STORE_ID`. This meant the assistant was not using its file search capabilities.

The parameter has been re-added, ensuring that the assistant correctly utilizes the provided files for its responses.