### PR TITLE
feat: Add monitoring screen and chat history sync

### DIFF
--- a/templates/admin.html
+++ b/templates/admin.html
@@ -188,6 +188,12 @@
         <div id="status-message"></div>
 
         <div class="section">
+            <h2>Синхронизация на чатове</h2>
+            <p>Натиснете бутона, за да качите цялата история на чатовете от базата данни във Vector Store на асистента. Това ще му позволи да използва минали разговори като база знания. Процесът може да отнеме няколко минути.</p>
+            <button id="sync-chats-btn" class="btn btn-primary">Синхронизирай чатове с базата знания</button>
+        </div>
+
+        <div class="section">
             <h2>Списък с качени файлове</h2>
             <div id="file-list-header">
                 <span>Име на файл</span>
@@ -208,6 +214,7 @@
             const fileInputLabelText = document.getElementById('file-input-label-text');
             const fileListContainer = document.getElementById('file-list-container');
             const statusMessage = document.getElementById('status-message');
+            const syncChatsBtn = document.getElementById('sync-chats-btn');
 
             const showStatus = (message, type) => {
                 statusMessage.textContent = message;
@@ -315,6 +322,31 @@
                 } finally {
                     uploadBtn.disabled = false;
                     uploadBtn.textContent = 'Качи';
+                }
+            });
+
+            syncChatsBtn.addEventListener('click', async () => {
+                syncChatsBtn.disabled = true;
+                syncChatsBtn.textContent = 'Синхронизиране...';
+                showStatus('Започва синхронизация. Моля, изчакайте...', 'success');
+
+                try {
+                    const response = await fetch('/api/sync-chats', { method: 'POST' });
+                    const result = await response.json();
+
+                    if (!response.ok) {
+                        throw new Error(result.error || 'Failed to sync chats.');
+                    }
+
+                    showStatus(result.message || 'Синхронизацията е успешна!', 'success');
+                    // Reload file list to show the new chat history file
+                    loadFiles();
+
+                } catch (error) {
+                    showStatus(error.message, 'error');
+                } finally {
+                    syncChatsBtn.disabled = false;
+                    syncChatsBtn.textContent = 'Синхронизирай чатове с базата знания';
                 }
             });
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -53,12 +53,30 @@
         .nav-links {
             display: flex;
             justify-content: space-around;
+            padding-top: 0.5rem;
         }
         .admin-link {
             font-size: 0.9em;
             color: #6c757d;
             text-decoration: none;
             font-weight: 500;
+        }
+        #history-section {
+            flex-grow: 1;
+            display: flex;
+            flex-direction: column;
+            overflow: hidden;
+        }
+        #history-summary {
+            padding: 1rem 0.5rem;
+            cursor: pointer;
+            font-weight: 600;
+            color: var(--text-dark);
+            border-top: 1px solid var(--border-grey);
+            margin-top: 8px;
+        }
+        #history-summary:hover {
+            background-color: #e9ecef;
         }
         .admin-link:hover {
             text-decoration: underline;
@@ -258,7 +276,10 @@
                     <a href="/monitoring" class="admin-link">Наблюдение на чатове</a>
                 </div>
             </div>
-            <div id="thread-list"></div>
+            <details id="history-section" open>
+                <summary id="history-summary">История на чатове</summary>
+                <div id="thread-list"></div>
+            </details>
         </div>
         <div id="chat-container">
             <div id="chat-header">Peugeot Наличности</div>
@@ -392,9 +413,13 @@
                         groupedThreads[group].forEach(thread => {
                             const item = document.createElement('div');
                             item.className = 'thread-item';
-                            item.textContent = thread.title || 'Нов чат';
+
+                            const threadDate = new Date(thread.created_at).toLocaleDateString('bg-BG');
+                            const titleText = `(${threadDate}) ${thread.title || 'Нов чат'}`;
+
+                            item.textContent = titleText;
                             item.dataset.threadId = thread.id;
-                            item.setAttribute('title', thread.title);
+                            item.setAttribute('title', titleText);
 
                             if (thread.id === threadId) {
                                 item.classList.add('active');


### PR DESCRIPTION
This commit introduces two major new features based on user requests: a collapsible UI for chat history and a mechanism to sync chat history from the database to the assistant's knowledge base.

UI/UX Improvements:
- The chat history sidebar in the main chat view is now collapsible under a 'История на чатове' dropdown, improving the default view.
- The date of the conversation is now prepended to each chat title in the list for better context.

New 'Monitoring' Screen:
- A new `/monitoring` page allows an administrator to view all chat sessions in near real-time (polling every 10 seconds).
- A takeover feature is implemented: when an admin sends a message in a monitored chat, the AI assistant is permanently disabled for that thread, allowing for human intervention.
- This required adding an `is_human_controlled` boolean column to the `chat_sessions` table in Supabase.

Chat History Sync to Vector Store:
- A new button in the `/admin` panel allows an administrator to sync the entire chat history from the Supabase database to the OpenAI Vector Store.
- This is handled by a new `/api/sync-chats` endpoint that fetches all messages, formats them into a text file in memory, uploads the file to OpenAI, and attaches it to the specified Vector Store. This allows the assistant to use past conversations as a knowledge source.