### PR TITLE
feat: Save and display car cards in chat history

### DIFF
--- a/app.py
+++ b/app.py
@@ -157,8 +157,9 @@ def chat():
                     arguments = json.loads(tool_call.function.arguments)
                     car_data_result = get_available_cars(model_filter=arguments.get('model_filter'))
                     
-                    # Save summary to DB before returning
-                    supabase.table('chat_messages').insert({"session_id": thread_id, "message": car_data_result['summary'], "is_user": False}).execute()
+                    # Save the full car data structure to the DB
+                    car_data_as_json = json.dumps(car_data_result, ensure_ascii=False)
+                    supabase.table('chat_messages').insert({"session_id": thread_id, "message": car_data_as_json, "is_user": False}).execute()
 
                     client.beta.threads.runs.submit_tool_outputs(
                         thread_id=thread_id,

--- a/templates/index.html
+++ b/templates/index.html
@@ -437,10 +437,26 @@
 
                     chatBox.removeChild(loading);
                     messages.forEach(msg => {
-                        // This logic needs to be updated when Supabase is integrated
-                        // to handle the `is_user` flag instead of `role`.
                         const role = msg.is_user ? 'user' : 'assistant';
-                        addMessage(msg.content, role);
+                        // For assistant messages, try to parse them as JSON
+                        if (role === 'assistant') {
+                            try {
+                                const data = JSON.parse(msg.content);
+                                // If parsing is successful and it has car data, display it
+                                if (data && data.cars) {
+                                    addCarsDisplay(data.summary, data.cars);
+                                } else {
+                                    // It's valid JSON, but not the structure we expect. Display as text.
+                                    addMessage(msg.content, role);
+                                }
+                            } catch (e) {
+                                // If it's not a valid JSON string, it's a regular text message.
+                                addMessage(msg.content, role);
+                            }
+                        } else {
+                            // User messages are always plain text
+                            addMessage(msg.content, role);
+                        }
                     });
                 } catch (error) {
                     console.error('Error loading messages:', error);


### PR DESCRIPTION
Previously, when the assistant displayed available cars from the XML feed, this information was only sent to the client for immediate display and was not persisted in the database. This meant that when a user reloaded a chat session, the car cards would disappear from the history.

This commit addresses the issue by:

1.  Modifying `app.py` to serialize the entire car data object (including the summary and the list of cars) into a JSON string and save it to the `chat_messages` table in the database.

2.  Updating the JavaScript in `templates/index.html` to handle the new format. When loading chat history, it now attempts to parse each assistant message as JSON. If a message contains car data, it is rendered using the dedicated car card display function. Otherwise, it is treated as a plain text message.