### PR TITLE
Hide text when displaying available cars

### DIFF
--- a/app.py
+++ b/app.py
@@ -315,10 +315,14 @@ def chat():
             response_text = messages.data[0].content[0].text.value
             print(f"DEBUG: Assistant response: {response_text[:100]}...")
 
+            # Ако имаме данни за коли, не показваме текстов отговор
+            if car_data_result and car_data_result.get('cars'):
+                response_text = ""
+
             # Записваме отговора в базата
             supabase.table('chat_messages').insert({
-                "session_id": thread_id, 
-                "message": response_text, 
+                "session_id": thread_id,
+                "message": response_text,
                 "is_user": False
             }).execute()
 
@@ -328,7 +332,7 @@ def chat():
                 "thread_id": thread_id,
                 "is_new_thread": is_new_thread
             }
-            
+
             if car_data_result and car_data_result.get('cars'):
                 response_data["cars"] = car_data_result['cars']
                 print(f"DEBUG: Including {len(car_data_result['cars'])} cars in response")

--- a/templates/index.html
+++ b/templates/index.html
@@ -278,7 +278,10 @@
             function addCarsDisplay(headerText, cars) {
                 const messageElement = document.createElement('div');
                 messageElement.classList.add('message', 'assistant-message');
-                let html = `<div class="cars-header">${headerText}</div>`;
+                let html = '';
+                if (headerText && headerText.trim() !== '') {
+                    html += `<div class="cars-header">${headerText}</div>`;
+                }
                 if (cars && cars.length > 0) {
                     html += '<div class="cars-container">';
                     cars.forEach(car => {


### PR DESCRIPTION
## Summary
- Suppress assistant text when car data is returned so UI shows only car cards.
- Render car cards without an empty header when no summary text is provided.

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a580185180832290e693e0b8a7b22c