### PR TITLE
Keep loading indicator until car cards show and tweak summary text

### DIFF
--- a/app.py
+++ b/app.py
@@ -143,7 +143,7 @@ def get_available_cars(model_filter=None):
             return {"summary": summary, "cars": []}
         
         if model_filter:
-            summary = f"Ето налични автомобили от {model_filter}:"
+            summary = f"Ето налични автомобили {model_filter}:"
         else:
             summary = "Ето налични автомобили:"
         

--- a/templates/index.html
+++ b/templates/index.html
@@ -338,7 +338,6 @@
                     } catch (e) {
                         throw new Error('Сървърът върна невалиден отговор.');
                     }
-                    loadingIndicator.remove();
 
                     if (!response.ok) throw new Error(data.error || `HTTP error! Status: ${response.status}`);
 
@@ -356,8 +355,9 @@
                     }
                 } catch (error) {
                     console.error('Error details:', error);
-                    loadingIndicator.remove();
                     addMessage(`Грешка: ${error.message}`, 'assistant');
+                } finally {
+                    loadingIndicator.remove();
                 }
             }
 


### PR DESCRIPTION
## Summary
- Keep typing bubbles visible until server response is fully processed
- Remove the word "от" from car summary headers

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a587c1b60c8322955b1ecd09eab048