### PR TITLE
Add admin interface to manage assistant files

### DIFF
--- a/templates/admin.html
+++ b/templates/admin.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="bg">
+<head>
+    <meta charset="UTF-8">
+    <title>Администрация</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 40px;
+        }
+        h1 { color: #003da5; }
+        ul { list-style: none; padding: 0; }
+        li { margin: 8px 0; }
+        button { margin-left: 8px; }
+    </style>
+</head>
+<body>
+    <h1>Управление на файлове</h1>
+    <form id="upload-form">
+        <input type="file" id="file-input" name="file" required />
+        <button type="submit">Качи</button>
+    </form>
+    <ul id="files"></ul>
+    <script>
+        async function loadFiles() {
+            const res = await fetch('/api/admin/files');
+            const files = await res.json();
+            const list = document.getElementById('files');
+            list.innerHTML = '';
+            files.forEach(f => {
+                const li = document.createElement('li');
+                const sizeKb = Math.round((f.bytes || 0) / 1024);
+                li.textContent = `${f.filename} (${sizeKb} KB)`;
+                const delBtn = document.createElement('button');
+                delBtn.textContent = 'Изтрий';
+                delBtn.addEventListener('click', async () => {
+                    await fetch(`/api/admin/files/${f.id}`, { method: 'DELETE' });
+                    loadFiles();
+                });
+                li.appendChild(delBtn);
+                list.appendChild(li);
+            });
+        }
+        document.getElementById('upload-form').addEventListener('submit', async (e) => {
+            e.preventDefault();
+            const input = document.getElementById('file-input');
+            if (!input.files.length) return;
+            const formData = new FormData();
+            formData.append('file', input.files[0]);
+            await fetch('/api/admin/files', { method: 'POST', body: formData });
+            input.value = '';
+            loadFiles();
+        });
+        loadFiles();
+    </script>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -62,6 +62,22 @@
         #new-chat-btn:hover {
             background-color: #002c8f;
         }
+        #admin-btn {
+            margin-top: 8px;
+            background-color: #6c757d;
+            color: var(--text-light);
+            border: none;
+            border-radius: 8px;
+            padding: 12px;
+            font-size: 1em;
+            font-weight: 500;
+            width: 100%;
+            cursor: pointer;
+            transition: background-color 0.2s;
+        }
+        #admin-btn:hover {
+            background-color: #5a6268;
+        }
         #thread-list {
             flex-grow: 1;
             overflow-y: auto;
@@ -237,6 +253,7 @@
         <div id="sidebar">
             <div id="sidebar-header">
                 <button id="new-chat-btn">+ Нов чат</button>
+                <button id="admin-btn">Администрация</button>
             </div>
             <div id="thread-list"></div>
         </div>
@@ -257,6 +274,7 @@
             const sendButton = document.getElementById('send-button');
             const threadList = document.getElementById('thread-list');
             const newChatBtn = document.getElementById('new-chat-btn');
+            const adminBtn = document.getElementById('admin-btn');
 
             let threadId = null;
 
@@ -264,6 +282,7 @@
             sendButton.addEventListener('click', sendMessage);
             chatInput.addEventListener('keypress', (e) => e.key === 'Enter' && sendMessage());
             newChatBtn.addEventListener('click', startNewChat);
+            adminBtn.addEventListener('click', () => window.location.href = '/admin');
 
             // --- Core Functions ---
             function addMessage(text, sender) {


### PR DESCRIPTION
## Summary
- add administration page with ability to upload, list and delete assistant files
- expose API routes for file management backed by OpenAI vector store
- link admin view from main sidebar

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a588e05c2c8322b050467a31a94617