### PR TITLE
Persist car cards across sessions

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -463,10 +463,12 @@
 
                     loading.remove();
                     messages.forEach(msg => {
-                        // This logic needs to be updated when Supabase is integrated
-                        // to handle the `is_user` flag instead of `role`.
                         const role = msg.is_user ? 'user' : 'assistant';
-                        addMessage(msg.content, role);
+                        if (msg.cars) {
+                            addCarsDisplay(msg.message, msg.cars);
+                        } else {
+                            addMessage(msg.message, role);
+                        }
                     });
                 } catch (error) {
                     console.error('Error loading messages:', error);


### PR DESCRIPTION
## Summary
- Save assistant car cards to `chat_messages` so they can be reloaded later
- Return stored car cards when fetching thread history
- Update frontend to render saved car cards during history load

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a58a3a50f08322a740c4531a3972d3