### PR TITLE
Use fallback vector store ID for admin file list

### DIFF
--- a/app.py
+++ b/app.py
@@ -20,8 +20,10 @@ app = Flask(__name__)
 client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
 ASSISTANT_ID = os.getenv("OPENAI_ASSISTANT_ID")
 # Render задава идентификатора на вектор сториджа чрез променливата
-# "VECTOR_STORE_ID", затова я използваме директно тук.
-VECTOR_STORE_ID = os.getenv("VECTOR_STORE_ID")
+# "VECTOR_STORE_ID", затова я използваме директно тук. Ако променливата
+# не е зададена (например в локална среда), използваме стойността
+# предоставена от клиента като подразбиране.
+VECTOR_STORE_ID = os.getenv("VECTOR_STORE_ID") or "vs_yN7KvCiOMQuQjeqXnAMH8tGO"
 
 # Supabase Client
 supabase_url = os.getenv("SUPABASE_URL")


### PR DESCRIPTION
## Summary
- Default the vector store ID to `vs_yN7KvCiOMQuQjeqXnAMH8tGO` when the `VECTOR_STORE_ID` env var is missing so the admin panel can load files

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a59114c85883229f4cad3480b8fd7b